### PR TITLE
Minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ stats
 _stats
 _site
 .jekyll-cache
-_site
 stats
+.DS_Store

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,7 +16,7 @@
 
           <div id="site-title">
           <h1 class="h0-title inline-block sm-width-full py-2 mt-3 header-title" style="z-index:10; position:relative;">{{ site.title }}</h1>
-          <svg id="orbit" style="margin-top:-360px" width="433" height="453" viewBox="0 0 433 453" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg id="orbit" style="margin-top:-270px" width="325" height="340" viewBox="0 0 433 453" fill="none" xmlns="http://www.w3.org/2000/svg">
           <g clip-path="url(#clip0_101_8)">
           <path d="M298.451 341.544C391.556 275.556 430.536 170.565 385.514 107.041C340.491 43.5167 228.516 45.5136 135.411 111.501C42.305 177.489 3.32565 282.479 48.3479 346.004C93.3702 409.528 205.345 407.531 298.451 341.544Z" stroke="#ADE9FF" stroke-width="2" stroke-miterlimit="10"/>
           <path d="M328.41 292.336C328.41 292.336 326.537 305.585 330.403 310.561C334.27 315.537 339.052 321.433 343.401 322.525C335.713 324.047 334.226 321.796 325.609 326.6C317.705 330.938 317.017 336.138 314.743 343.746C315.573 335.279 316.823 323.973 309.316 318.535C301.809 313.097 299.368 311.313 297.202 310.739C297.202 310.739 309.601 311.158 313.524 308.719C317.447 306.281 326.004 299.685 328.41 292.336Z" fill="#ADE9FF"/>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -92,7 +92,7 @@
     </div>
 
     <div class="tournament-card blue">
-      <span class="date">April 20-21, 2024</span>
+      <span class="date">April 20–21, 2024</span>
       <h2>2024 ACF Nationals</h2>
       <span class="head-editors">Head edited by Nick Jensen</span><br />
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -110,13 +110,13 @@
 
       <!-- <a href="/fall">Tournament information →</a> -->
     </div>
-    <div class="tournament-card">
+    <!-- <div class="tournament-card">
       <span class="date">TBA</span>
       <h2>2024 ACF Winter</h2>
-      <span class="head-editors">Head edited by Chris Sims</span>
+      <span class="head-editors">Head edited by Chris Sims</span> -->
 
       <!-- <a href="/fall">Tournament information →</a> -->
-    </div>
+    <!-- </div> -->
     </div>
 
     </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -66,11 +66,12 @@
     <!-- The next upcoming tournament should have the .blue class, so only one tournament
     at a time will have the blue gradient. -->
 
-    <div id="tournaments">
+    <h1>This season</h1>
+    <div class="tournaments">
     <div class="tournament-card">
-      <span class="date">TBA</span>
-      <h2>2024 ACF Fall</h2>
-      <span class="head-editors">Head edited by Alexandra Hardwick</span><br /><br />
+      <span class="date">October 14, 2023</span>
+      <h2>2023 ACF Fall</h2>
+      <span class="head-editors">Head edited by Sean Farrell</span><br /><br />
 
         <a href="/fall">Tournament information →</a>
     </div>
@@ -98,6 +99,26 @@
 
       <a href="/nationals">Tournament information →</a>
     </div>
+    </div>
+
+    <h1>Next season</h1>
+    <div class="tournaments">
+    <div class="tournament-card">
+      <span class="date">TBA</span>
+      <h2>2024 ACF Fall</h2>
+      <span class="head-editors">Head edited by Alexandra Hardwick</span>
+
+      <!-- <a href="/fall">Tournament information →</a> -->
+    </div>
+    <div class="tournament-card">
+      <span class="date">TBA</span>
+      <h2>2024 ACF Winter</h2>
+      <span class="head-editors">Head edited by Chris Sims</span>
+
+      <!-- <a href="/fall">Tournament information →</a> -->
+    </div>
+    </div>
+
     </div>
 
 

--- a/assets/home.scss
+++ b/assets/home.scss
@@ -15,7 +15,7 @@
   margin-bottom:0px;
 
   .header-title {
-    font-size:4em;
+    font-size:3em;
     font-family:'Merriweather', sans-serif;
     line-height:120%;
     margin:0;
@@ -57,10 +57,6 @@
   border-radius:4px;
   width:calc(25% - 15px);
   box-sizing: border-box;
-  display:flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: flex-start;
 
   @media only screen and (max-width: $medium-screen) {
     width:calc(50% - 10px);

--- a/assets/home.scss
+++ b/assets/home.scss
@@ -42,7 +42,7 @@
   }
 }
 
-#tournaments {
+.tournaments {
   display:flex;
   justify-content:space-evenly;
   flex-wrap:wrap;
@@ -109,7 +109,7 @@
     }
 }
 
-#updates-heading {
+body.home h1 {
   color:$blue-dark;
   padding-top:15px;
   text-align:center;

--- a/assets/home.scss
+++ b/assets/home.scss
@@ -44,29 +44,30 @@
 
 .tournaments {
   display:flex;
-  justify-content:space-evenly;
+  justify-content:flex-start;
   flex-wrap:wrap;
-  width:100vw;
+  padding: 0 20px 10px;
+  gap: 20px;
+  width: 100%;
 }
 
 .tournament-card {
   background:#d9eaff;
   padding:1em 1.5em;
   border-radius:4px;
-  width:calc(25% - 20px);
+  width:calc(25% - 15px);
   box-sizing: border-box;
-  margin-bottom:10px;
   display:flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
 
   @media only screen and (max-width: $medium-screen) {
-    width:48vw;
+    width:calc(50% - 10px);
   }
 
   @media only screen and (max-width: $small-screen) {
-    width:100vw;
+    width:100%;
   }
 
   .date {

--- a/assets/home.scss
+++ b/assets/home.scss
@@ -57,6 +57,10 @@
   border-radius:4px;
   width:calc(25% - 15px);
   box-sizing: border-box;
+  display:flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
 
   @media only screen and (max-width: $medium-screen) {
     width:calc(50% - 10px);

--- a/guidelines/policies.md
+++ b/guidelines/policies.md
@@ -21,7 +21,7 @@ ACF also reserves the right to deny or alter a team’s choice of pseudonym for 
 Individual players must use (1) their legal name, (2) a preferred name that they use regularly, or a clear nickname or variant of either (1) or (2).
 Individual players may not use pseudonyms to obscure their identity or impersonate others.
 
-# High School Editors
-High schoolers are welcome to apply to edit ACF sets. Like other editors, ACF’s membership will vote to offer provisional membership based on their merits such as quality of work, responsiveness to feedback, and communication. The vote will occur with the other editors at the meeting immediately following the tournament they produced. If offered provisional membership, it will be offered to the high school-age editor immediately.
+# High-school editors
+High schoolers are welcome to apply to edit ACF sets. Just like other editors, ACF’s membership will vote to offer provisional membership to the editor based on their merits (such as quality of work, responsiveness to feedback, and communication). The vote will occur with the other editors at the first ACF meeting immediately following the tournament they produced. If offered provisional membership, it will be offered to the high-school-age editor immediately.
 
-High schoolers may not become full members of ACF while still in high school. If a high school-aged editor produces work that the membership extends an offer of full membership for, the full membership will be offered and begin immediately after the high schooler’s graduation.
+High schoolers may not become full members of ACF while still in high school. If a high-school-aged editor produces work that the membership extends an offer of full membership for, the full membership will be offered and begin immediately after the high schooler’s graduation.

--- a/guidelines/policies.md
+++ b/guidelines/policies.md
@@ -22,6 +22,6 @@ Individual players must use (1) their legal name, (2) a preferred name that they
 Individual players may not use pseudonyms to obscure their identity or impersonate others.
 
 # High-school editors
-High schoolers are welcome to apply to edit ACF sets. Just like other editors, ACF’s membership will vote to offer provisional membership to the editor based on their merits (such as quality of work, responsiveness to feedback, and communication). The vote will occur with the other editors at the first ACF meeting immediately following the tournament they produced. If offered provisional membership, it will be offered to the high-school-age editor immediately.
+High schoolers are welcome to apply to edit ACF sets. Like other editors, ACF’s membership will vote to offer provisional membership to the editor based on their merits (such as quality of work, responsiveness to feedback, and communication). The vote will occur with the other editors at the first ACF meeting immediately following the tournament they produced. If offered provisional membership, it will be offered to the high-school-age editor immediately.
 
 High schoolers may not become full members of ACF while still in high school. If a high-school-aged editor produces work that the membership extends an offer of full membership for, the full membership will be offered and begin immediately after the high schooler’s graduation.

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ layout: home
 
 <!-- Set title and description in config.yml -->
 
-<h1 id="updates-heading">Recent updates</h1>
+<h1>Recent updates</h1>
 
 #### July 9, 2023
 [2023-24 subject editors announced](https://hsquizbowl.org/forums/viewtopic.php?p=395751#p395751)

--- a/index.md
+++ b/index.md
@@ -4,6 +4,8 @@ layout: home
 
 <!-- Set title and description in config.yml -->
 
+{% comment %}
+
 <h1>Recent updates</h1>
 
 #### July 9, 2023
@@ -17,8 +19,6 @@ layout: home
 #### June 7, 2023
 [2023-24 officers, head editors, and member changes announced](https://hsquizbowl.org/forums/viewtopic.php?p=395399#p395399)
 : 
-
-{% comment %}
 
 #### January 31, 2023
 [2023 ACF Regionals A-values](https://hsquizbowl.org/forums/viewtopic.php?p=393225#p393225)


### PR DESCRIPTION
* Split tournaments cards on home page into "this season"/"next season". Non-chronological order may be confusing (esp. when the lineup is `2024 Fall, 2024 Winter, 2024 Regionals, 2024 Nationals`). More especially, the `/fall` link still holds information for the past instance of the tournament anyway.
* Reduce vertical space on home page
* Improve wording of new policy
* Comment out old recent changes