### PR TITLE
Update hosting guideline fee structure, add fall/winter sites

### DIFF
--- a/guidelines/hosting-guidelines.md
+++ b/guidelines/hosting-guidelines.md
@@ -201,9 +201,8 @@ ACF encourages all hosts to run their tournaments digitally in order to be envir
 # Details about finances
 ## Financial breakdown between hosts and ACF
 This section is subject to change.
-In-person mirrors of 2021 ACF Fall will use the Base fee, New to quizbowl discount, and Shorthanded discount listed for online tournaments instead.
 
-### For in-person tournaments
+### ACF Winter, Regionals
 
 <table>
 <thead>
@@ -254,14 +253,14 @@ In-person mirrors of 2021 ACF Fall will use the Base fee, New to quizbowl discou
 </tr>
 <tr>
 <td>Staffers<sup style="font-size:65%;">3</sup></td>
-<td>−$15 per staffer</td>
-<td>−$15 per staffer</td>
+<td>−$25 per staffer</td>
+<td>−$25 per staffer</td>
 <td>n/a</td>
 </tr>
 </tbody>
 </table>
 
-### For online tournaments
+### ACF Fall
 
 <table>
 <thead>
@@ -297,6 +296,18 @@ In-person mirrors of 2021 ACF Fall will use the Base fee, New to quizbowl discou
 <td>± amount as applicable</td>
 <td>n/a</td>
 <td>± amount as applicable</td>
+</tr>
+<tr>
+<td>Travel discount<sup style="font-size:65%;">1</sup></td>
+<td>−$10 per 200 miles traveled one-way</td>
+<td>−$10 per 200 miles traveled one-way</td>
+<td>n/a</td>
+</tr>
+<tr>
+<td>Buzzers<sup style="font-size:65%;">2</sup></td>
+<td>−$10 per buzzer</td>
+<td>−$10 per buzzer</td>
+<td>n/a</td>
 </tr>
 <tr>
 <td>Staffers<sup style="font-size:65%;">3</sup></td>

--- a/tournaments/ACF Fall.md
+++ b/tournaments/ACF Fall.md
@@ -102,28 +102,27 @@ Your assigned half-packet or quarter-packet may ask for questions from more spec
 ACF Fall uses the [standard ACF distribution](/distribution).
 
 ## Hosting
-If you are interested in hosting a mirror of ACF Fall, fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfFTYPxmESIxJLLDi8G37ImpOfgaggTdoLo2-kabgm6tGOWJQ/viewform?usp=sf_link) before 11:59 p.m. Pacific Time on Saturday, August 17, 2024. Mirrors of this tournament may be held in-person or online. If you have any questions about hosting, please email ACF’s Site Coordinator at hosting@acf-quizbowl.com. Hosts must abide by ACF’s Hosting Guidelines.
 
 Mirrors will by default be regional. ACF reserves the right to move teams and staffers between sites. ACF intends to mirror 2024 ACF Fall in the following [regions](/hosting-guidelines#regions-according-to-acf):
 
 Region                          | Site
 -                               | -
-Northeast | MIT
+Northeast | [MIT](https://hsquizbowl.org/forums/viewtopic.php?t=28304)
 Upper Mid-Atlantic | [Rutgers](https://hsquizbowl.org/forums/viewtopic.php?t=28271)
 Upstate NY | [Cornell](https://hsquizbowl.org/forums/viewtopic.php?t=28286)
 Lower Mid-Atlantic | [UNC Chapel Hill](https://hsquizbowl.org/forums/viewtopic.php?t=28279)
 Southeast | [Georgia](https://hsquizbowl.org/forums/viewtopic.php?t=28288)
 Florida | [University of Central Florida](https://hsquizbowl.org/forums/viewtopic.php?t=28281)
 Great Lakes | [Ohio State](https://hsquizbowl.org/forums/viewtopic.php?t=28252)
-Midwest | UIUC
-North | Minnesota
+Midwest | [UIUC](https://hsquizbowl.org/forums/viewtopic.php?t=28329)
+North | [Minnesota](https://hsquizbowl.org/forums/viewtopic.php?t=28309)
 South Central | [Murray State College](https://hsquizbowl.org/forums/viewtopic.php?t=28257)
 Pacific Northwest/Mountain West | [Washington](https://hsquizbowl.org/forums/viewtopic.php?t=28256)
 Northern California | [UC Berkeley](https://hsquizbowl.org/forums/viewtopic.php?t=28295)
 Southern California | [Claremont Colleges](https://hsquizbowl.org/forums/viewtopic.php?t=28267)
 Eastern Canada | [Ottawa](https://hsquizbowl.org/forums/viewtopic.php?t=28282)
-Northern United Kingdom | Durham
-Southern United Kingdom | Southampton 
+Northern United Kingdom | [Durham](https://hsquizbowl.org/forums/viewtopic.php?t=28308)
+Southern United Kingdom | [Southampton](https://hsquizbowl.org/forums/viewtopic.php?t=28307) 
 
 ## High-school-only sites:
 

--- a/tournaments/ACF Winter.md
+++ b/tournaments/ACF Winter.md
@@ -3,7 +3,7 @@ layout: page
 title: ACF Winter
 permalink: /winter/
 nav_order: 2.5
-last_updated: June 16, 2024
+last_updated: October 6, 2024
 ---
 
 **ACF Winter** is a medium-difficulty tournament (halfway between ACF Fall and ACF Regionals). It is meant for players with a variety of experiences: from players in their first semester of college quizbowl, to players who have been to ACF Nationals. ACF Winter was revived in 2020; the original iterations of ACF Winter were held in 2009 and 2010.
@@ -116,31 +116,26 @@ More information can be found in [ACF’s packet submission guidelines](/packet-
 ## Eligibility
 For information on who is eligible to play ACF tournaments, see [ACF’s official Eligibility Rules](/eligibility-rules).
 
-## Hosting
-We are looking for hosts in the regions listed in the “Hosting” section below. The host bid form is [here](https://docs.google.com/forms/d/e/1FAIpQLSf-Uwkx7ait1W0WR-2QeRiJmyymIy9ywvZqTp82IHfbzb-9Dw/viewform). Please submit bids by Sunday, September 3rd at 11:59 PM PT. If you have any questions about hosting or about the form, email ACF’s Site Coordinator at [hosting@acf-quizbowl.com](mailto:hosting@acf-quizbowl.com) and CC [winter@acf-quizbowl.com](mailto:winter@acf-quizbowl.com). Online sites are optional. Hosts must abide by [ACF’s Hosting Guidelines](/hosting-guidelines).
-
 ## Mirrors
 Mirrors will by default be regional. ACF reserves the right to move teams and staffers between sites. ACF intends to mirror 2024 ACF Winter in the following [regions](/hosting-guidelines#regions-according-to-acf):
 
 Region                    | Site
--                         | -
-Northeast                 |
-Upper Mid-Atlantic        |
-Upstate NY                |
-Lower Mid-Atlantic        |
-Southeast                 |
-Florida                   |
-Great Lakes               |
-Midwest                   |
-North                     |
-South Central             |
-Pacific Northwest/Mountain West:    | 
-Northern California       |
-Southern California       |
-Northwest                 |
-Eastern Canada            |
-United Kingdom            |
-Overflow (online)         |
+-                         | - 
+Northeast                 | Brandeis
+Upper Mid-Atlantic        | [Lehigh](https://hsquizbowl.org/forums/viewtopic.php?t=28375)
+Upstate NY                | [University of Rochester](https://hsquizbowl.org/forums/viewtopic.php?t=28393)
+Lower Mid-Atlantic        | University of Virginia
+Southeast                 | [Clemson](https://hsquizbowl.org/forums/viewtopic.php?p=402337#p402337)
+Florida                   | [UCF](https://hsquizbowl.org/forums/viewtopic.php?p=402352#p402352)
+Great Lakes               | The Ohio State University
+Midwest                   | [Northwestern](https://hsquizbowl.org/forums/viewtopic.php?t=28389)
+North                     | University of Minnesota
+South Central             | [UT Austin](https://hsquizbowl.org/forums/viewtopic.php?p=402359#p402359)
+Pacific Northwest/Mountain West:    | University of British Columbia
+Northern California       | UC Berkeley
+Eastern Canada            | [University of Toronto](https://hsquizbowl.org/forums/viewtopic.php?p=402393#p402393)
+United Kingdom            | Oxford University
+Overflow (online)         | TBD
 
 ## Past tournaments
 Sample questions from previous iterations of ACF Winter are on the [Collegiate Quizbowl Packet Archive](http://hsquizbowl.org/db/questionsets/search/?name=ACF+Winter&col=1&season=&archived=y).


### PR DESCRIPTION
Update [Hosting Guidelines](https://acf-quizbowl.com/hosting-guidelines/#financial-breakdown-between-hosts-and-acf) to reflect currently-used fee structure

Add sites for Winter, add additional links for Fall sites